### PR TITLE
chore(frontend): bump footer label to v0.1.1

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -65,7 +65,17 @@ export default function App() {
         </div>
       </section>
 
-      <div className="footer-note">Нажимай на кнопки сверху, чтобы переключать объекты</div>
+      <footer
+        style={{
+          position: "fixed",
+          bottom: 5,
+          right: 10,
+          color: "gray",
+          fontSize: "12px"
+        }}
+      >
+        Black Hole Gallery v0.1.1
+      </footer>
     </div>
   );
 }


### PR DESCRIPTION
## What has changed
- Replaced `<div>` with a proper `<footer>`.
- Added version label "Black Hole Gallery v0.1.1" at the bottom right corner.

## Why
- Demonstrates feature branching and pull request workflow.
- Adds a clear example of a minor frontend improvement.

## How to test
1. Run frontend locally: `npm run dev`.
2. Open http://localhost:5173
3. A footer label `Black Hole Gallery v0.1.1`
