### PR TITLE
feat(backend): add /ping endpoint for health check

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -43,4 +43,9 @@ def health():
 def version():
     return {"version": "0.1.0"}
 
+@app.get("/ping")
+def ping():
+    return {"status": "ok", "message": "pong"}
+
+
 app.include_router(blackholes_router)


### PR DESCRIPTION
## What has changed
- Added `/ping` endpoint in FastAPI backend.

## Why
- Provides a lightweight health-check endpoint.
- Common practice in DevOps/SRE to monitor service availability.

## How to test
1. Run backend locally: `uvicorn app.main:app --reload`
2. Open http://localhost:8000/ping
3. Response should be: `{"status":"ok","message":"pong"}`
