### PR TITLE
Ci/backend tests

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,20 +1,71 @@
 name: backend-tests
+
 on:
-  push: { paths: ['backend/**','.github/workflows/backend-tests.yml'] }
-  pull_request: { paths: ['backend/**'] }
+  push:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-tests.yml'
+  pull_request:
+    paths:
+      - 'backend/**'
+
 jobs:
   test:
     runs-on: ubuntu-latest
-    defaults: { run: { working-directory: backend } }
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.11', '3.12']
+
+    defaults:
+      run:
+        working-directory: backend
+
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with: { python-version: '3.11', cache: 'pip' }
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
       - name: Install deps
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
-          pip install pytest httpx || true
-      - name: Run tests
-        run: pytest -q tests
+          pip install pytest pytest-cov httpx coverage
+
+      - name: Run tests (with coverage)
+        run: |
+          pytest tests \
+            -q --maxfail=1 --disable-warnings \
+            --cov=. --cov-report=term-missing \
+            --cov-report=xml:coverage.xml \
+            --junitxml=pytest-report.xml
+
+      - name: Add coverage to job summary
+        if: always()
+        run: |
+          python - <<'PY'
+          import os, xml.etree.ElementTree as ET
+          rate = 0.0
+          try:
+              rate = float(ET.parse('coverage.xml').getroot().get('line-rate','0'))*100
+          except Exception as e:
+              print("No coverage.xml or parse error:", e)
+          with open(os.environ['GITHUB_STEP_SUMMARY'],'a', encoding='utf-8') as f:
+              f.write(f"### Python ${{ matrix.python-version }} coverage: {rate:.1f}%\n")
+          PY
+
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-artifacts-py${{ matrix.python-version }}
+          path: |
+            backend/coverage.xml
+            backend/.coverage
+            backend/pytest-report.xml


### PR DESCRIPTION
CI: Backend tests workflow (matrix 3.11/3.12) + coverage + artifacts

What this PR adds

GitHub Actions workflow for backend tests.

Triggers on push/pull_request affecting backend/**.

Runs on Python 3.11 and 3.12 (matrix).

Installs deps and runs pytest from backend/.

Collects coverage (coverage.xml, .coverage) and JUnit report.

Publishes coverage summary in the job output.

Uploads test artifacts for debugging