### PR TITLE
ci(frontend): deploy via OIDC + S3 versions + rollback

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -1,12 +1,22 @@
-name: Frontend Deploy
+name: Frontend Deploy (S3 + versions)
 
 on:
   push:
-    branches: [ main ]                 # деплоим после merge в main
+    branches: [ main ]
     paths:
       - "frontend/**"
-
+      - ".github/workflows/frontend-deploy.yml"
+      - "package*.json"
   workflow_dispatch:
+    inputs:
+      promote_version:
+        description: "Rollback: SHA релиза из s3://<bucket>/releases/<SHA>/"
+        required: false
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
 
 concurrency:
   group: frontend-deploy
@@ -15,6 +25,12 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      ROLE_ARN:   ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+      BUCKET:     ${{ secrets.S3_BUCKET }}
+      CF_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+      VERSION:    ${{ github.sha }}
 
     steps:
       - name: Checkout
@@ -31,33 +47,70 @@ jobs:
         working-directory: frontend
         run: npm ci
 
-      - name: Build (VITE_API_URL из секретов)
+      - name: Build (pass API URL from secrets)
         working-directory: frontend
         env:
           VITE_API_URL: ${{ secrets.VITE_API_URL }}
         run: npm run build
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id:     ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region:            ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ env.ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
 
-      - name: Upload static assets (long cache)
+      # ===== Rollback по SHA (без пересборки) =====
+      - name: Promote old version (rollback)
+        if: ${{ inputs.promote_version != '' }}
         run: |
-          aws s3 sync frontend/dist/ s3://${{ secrets.S3_BUCKET }} --delete \
-            --exclude index.html \
+          set -e
+          SHA="${{ inputs.promote_version }}"
+          SRC="s3://${BUCKET}/releases/${SHA}/"
+          echo "Checking: $SRC"
+          aws s3 ls "$SRC" || { echo "No such release: $SRC"; exit 1; }
+
+          # делаем активной папку current/
+          aws s3 sync "$SRC" "s3://${BUCKET}/current/" --delete
+
+          # временно дублируем в корень (пока OriginPath CF не /current)
+          aws s3 sync "s3://${BUCKET}/current/" "s3://${BUCKET}/" --delete
+
+          # инвалидация
+          if [ -n "${CF_DISTRIBUTION_ID}" ]; then
+            aws cloudfront create-invalidation \
+              --distribution-id "$CF_DISTRIBUTION_ID" \
+              --paths "/*"
+          fi
+          echo "Rollback to $SHA done."
+
+      # ===== Обычный деплой новой версии =====
+      - name: Upload release + promote to current
+        if: ${{ inputs.promote_version == '' }}
+        run: |
+          set -e
+
+          # 1) заливаем всё в releases/<sha>/ (статике даём длинный кеш)
+          aws s3 sync frontend/dist "s3://${BUCKET}/releases/${VERSION}/" \
+            --delete \
+            --exclude "index.html" \
             --cache-control "public,max-age=31536000,immutable"
 
-      - name: Upload index.html (no-cache)
-        run: |
-          aws s3 cp frontend/dist/index.html s3://${{ secrets.S3_BUCKET }}/index.html \
+          # 2) index.html отдельно (без кеша)
+          aws s3 cp frontend/dist/index.html "s3://${BUCKET}/releases/${VERSION}/index.html" \
             --cache-control "no-cache, no-store, must-revalidate" \
             --content-type "text/html"
 
-      - name: Invalidate index.html
-        run: |
-          aws cloudfront create-invalidation \
-            --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} \
-            --paths "/index.html"
+          # 3) делаем релиз активным: sync -> current/
+          aws s3 sync "s3://${BUCKET}/releases/${VERSION}/" "s3://${BUCKET}/current/" --delete
+
+          # 4) временно дублируем в корень (пока OriginPath CF не /current)
+          aws s3 sync "s3://${BUCKET}/current/" "s3://${BUCKET}/" --delete
+
+          # 5) инвалидация
+          if [ -n "${CF_DISTRIBUTION_ID}" ]; then
+            aws cloudfront create-invalidation \
+              --distribution-id "$CF_DISTRIBUTION_ID" \
+              --paths "/*"
+          fi
+
+          echo "Deployed version: ${VERSION}"


### PR DESCRIPTION
Triggers on pushes to main affecting frontend/**

Builds with Node 20 and VITE_API_URL from secrets

Uploads assets with long cache, index.html with no-cache

Creates a CloudFront invalidation

Concurrency guard: frontend-deploy